### PR TITLE
fix: modify init-argo.sh to create all appprojects

### DIFF
--- a/enviroment/Deploy-Enviroment/init-argo.sh
+++ b/enviroment/Deploy-Enviroment/init-argo.sh
@@ -6,14 +6,12 @@ cd ..
 
 kubectl apply -f HC-Vault-Boost-argocd-configs/manifests/dev/appprojects/infra-argocd.yaml
 sleep 5
-
-kubectl apply -f HC-Vault-Boost-argocd-configs/manifests/dev/infra-apps.yaml
-sleep 5
-kubectl -n infra-argocd wait pods --selector app.kubernetes.io/instance=argocd --for condition=Ready --timeout=90s
+kubectl apply -f HC-Vault-Boost-argocd-configs/manifests/dev/appprojects/
 sleep 5
 kubectl apply -f HC-Vault-Boost-argocd-configs/manifests/dev/
 sleep 5
-kubectl apply -f HC-Vault-Boost-argocd-configs/manifests/dev/appprojects/appprojects.yaml
+kubectl -n infra-argocd wait pods --selector app.kubernetes.io/instance=argocd --for condition=Ready --timeout=90s
+sleep 5
 
 # get admin password
 echo "argocd, admin , $(kubectl -n infra-argocd get secret argocd-initial-admin-secret -o jsonpath="{.data.password}" | base64 -d)" >> passwords.csv


### PR DESCRIPTION
As mentioned [here](https://git.adfinis.com/ch-cloudnative/team-coordination/-/issues/364#note_414738), the init-argo.sh doesn't apply correctly all the manifests. I have done modifications so they are applied all and in the correct order.